### PR TITLE
Remove superfluous newline characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,5 +289,3 @@ The sample profile above could be chunked as follows:
     "linkedin": { "url": "http://www.linkedin.com/in/someuser" }
 }
 </pre></code>
-
-


### PR DESCRIPTION
The end of the document had too many newline characters.
