### PR TITLE
Added name and relationship fields to the orgs field in the profile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ For profiles to be properly read by OneName crawlers and displayed on OneName pr
     <tr>
         <td>orgs</td>
         <td>A list of organizations the user belongs to.</td>
-        <td>[{ "url": "http://mypersonalwebsite.com" }, { "url": "http://somecorporation.com" }]</td>
+        <td>[{ "url": "http://mypersonalwebsite.com" }, { "name": "Organization name", "relationship": "Your Title", "url": "http://somecorporation.com" }]</td>
     </tr>
     <tr>
         <td>v</td>


### PR DESCRIPTION
This would be for noting the name of the entity that manages the website and your relationship, such as "Contributing Author," "Owner," "Webmaster," etc.  A standardization of terminology here, particularly as it applies to authorship could be used for verification of authorship, such as Google's implementation of Authorship through G+.
