### PR TITLE
Improvements to ONS 0.3 rfc

### DIFF
--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -24,7 +24,7 @@ schema = {
                 }
             }
         },
-        "name": {
+        "names": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -44,7 +44,26 @@ schema = {
                 }
             }
         }
-        "photos": {
+        "urls": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            }
+        }        "photos": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -87,20 +106,6 @@ schema = {
                         "type": "string"
                     },
                     "proof": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "websites": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "label": {
                         "type": "string"
                     },
                     "url": {

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -181,17 +181,6 @@ schema = {
                 }
             }
         },
-        "pgp": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "fingerprint": {
-                    "type": "string"
-                }
-            }
-        },
         "v": {
             "type": "string",
             "description": "version number"

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -104,6 +104,26 @@ schema = {
                 }
             }
         }
+        "mail": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "address": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "payments": {
             "type": "array",
             "items": {
@@ -129,20 +149,6 @@ schema = {
                 },
                 "fingerprint": {
                     "type": "string"
-                }
-            }
-        },
-        "email": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "label": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    }
                 }
             }
         },

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -172,15 +172,18 @@ schema = {
                     "type": {
                         "type": "string"
                     },
-                    "address": {
-                        "type": "string"
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
-                    "proof": {
+                    "address": {
                         "type": "string"
                     }
                 }
             }
-        },
+        }
         "v": {
             "type": "string",
             "description": "version number"

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -144,6 +144,26 @@ schema = {
                 }
             }
         }
+        "fingerprints": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "fingerprint": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "payments": {
             "type": "array",
             "items": {

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -84,7 +84,7 @@ schema = {
                 }
             }
         }
-        "photos": {
+        "images": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -92,12 +92,18 @@ schema = {
                     "type": {
                         "type": "string"
                     },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "url": {
                         "type": "string"
                     }
                 }
             }
-        },
+        }
         "payments": {
             "type": "array",
             "items": {

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -184,6 +184,26 @@ schema = {
                 }
             }
         }
+        "locations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "location": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "v": {
             "type": "string",
             "description": "version number"

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -213,6 +213,26 @@ schema = {
                 }
             }
         }
+        "proof": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "location": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "v": {
             "type": "string",
             "description": "version number"

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -16,9 +16,6 @@ schema = {
         "basics": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
-                },
                 "location": {
                     "type": "string"
                 },
@@ -27,6 +24,26 @@ schema = {
                 }
             }
         },
+        "name": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "photos": {
             "type": "array",
             "items": {

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -63,7 +63,8 @@ schema = {
                     }
                 }
             }
-        }        "photos": {
+        }
+        "photos": {
             "type": "array",
             "items": {
                 "type": "object",

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -124,6 +124,26 @@ schema = {
                 }
             }
         }
+        "im": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "address": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
         "payments": {
             "type": "array",
             "items": {

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -13,17 +13,6 @@ schema = {
     "title": "ONS User Profile",
     "type": "object",
     "properties": {
-        "basics": {
-            "type": "object",
-            "properties": {
-                "location": {
-                    "type": "string"
-                },
-                "bio": {
-                    "type": "string"
-                }
-            }
-        },
         "names": {
             "type": "array",
             "items": {
@@ -199,6 +188,26 @@ schema = {
                         }
                     },
                     "location": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+        "text": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "text": {
                         "type": "string"
                     }
                 }

--- a/openspecs/userschema_rfc/schema.py
+++ b/openspecs/userschema_rfc/schema.py
@@ -58,6 +58,26 @@ schema = {
                             "type": "string"
                         }
                     },
+                    "username": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+        "profiles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "attribute": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "url": {
                         "type": "string"
                     }
@@ -90,26 +110,6 @@ schema = {
                         "type": "string"
                     },
                     "proof": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "profiles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    },
-                    "username": {
-                        "type": "string"
-                    },
-                    "proof": {
-                        "type": "string"
-                    },
-                    "url": {
                         "type": "string"
                     }
                 }

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -82,6 +82,23 @@ A list of link to a user's images, including avatars and cover photos. Images ca
 * R
 * X
 
+#### Mail
+
+A list of asynchronous communication (email-like) addresses associated with a user.
+
+##### Suggested Types for Mail
+
+* email
+* bitmessage
+* freemail
+
+##### Suggested Attributes for Mail
+
+* personal
+* business
+* student
+* official
+
 #### Payments
 
 A user's payment details for various payment methods, including Bitcoin and other cryptocurrencies. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
@@ -89,10 +106,6 @@ A user's payment details for various payment methods, including Bitcoin and othe
 #### PGP
 
 A user's PGP key. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
-
-#### Email
-
-A user's email addresses.
 
 ### Example
 <pre><code>{

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -52,6 +52,18 @@ A user can establish proof of ownership outside of this schema by placing a file
 * store
 * *public key identifier*
 
+#### Profiles
+
+The site-specific username associated with a user on specific websites.
+
+##### Suggested Types for Profiles
+
+* *canonical link to the site (example: https://www.facebook.com)*
+
+##### Suggested Attributes for Profiles
+
+* *optional link to the user's profile page*
+
 #### Photos
 
 A user's photos, including their avatar and cover photo.
@@ -59,10 +71,6 @@ A user's photos, including their avatar and cover photo.
 #### Payments
 
 A user's payment details for various payment methods, including Bitcoin and other cryptocurrencies. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
-
-#### Profiles
-
-A user's social network profiles. A user can provide the appropriate usernames or urls, as well as provide proof of ownership of their accounts by referencing posts that only they could have produced (tweets, gists, etc.).
 
 #### PGP
 
@@ -87,11 +95,12 @@ A user's email addresses.
         "type": "website",
         "url": "https://angel.co/naval"
     }],
+    "profiles": [{
+        "type": "https://twitter.com"
+        "username": "naval"
+    }],
     "payments": [{
         "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
-    }],
-    "profiles": [{
-        "username": "naval", "type": "twitter"
     }],
     "photos": [{
         "type": "avatar",

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -54,7 +54,7 @@ A user can establish proof of ownership outside of this schema by placing a file
 
 #### Profiles
 
-The site-specific username associated with a user on specific websites.
+A list of site-specific username associated with a user on specific websites.
 
 ##### Suggested Types for Profiles
 
@@ -64,9 +64,23 @@ The site-specific username associated with a user on specific websites.
 
 * *optional link to the user's profile page*
 
-#### Photos
+#### Images
 
-A user's photos, including their avatar and cover photo.
+A list of link to a user's images, including avatars and cover photos. Images can include Gravatar-compatible ratings as attributes.
+
+##### Suggested Types for Images
+
+* avatar
+* cover
+
+##### Suggested Attributes for Images
+
+* personal
+* business
+* G
+* PG
+* R
+* X
 
 #### Payments
 
@@ -99,15 +113,15 @@ A user's email addresses.
         "type": "https://twitter.com"
         "username": "naval"
     }],
-    "payments": [{
-        "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
-    }],
-    "photos": [{
+    "images": [{
         "type": "avatar",
         "url": "https://pbs.twimg.com/profile_images/3696617328/667874c5936764d93d56ccc76a2bcc13.jpeg"
     }, {
         "type": "cover",
         "url": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"
+    }],
+    "payments": [{
+        "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
     }],
     "v": "0.3"
 }</code></pre>

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -120,13 +120,23 @@ A list of synchronous communication (instant messaging) addresses associated wit
 * mobile
 * fax
 
+#### Fingerprints
+
+A list of public key fingerprints associated with a user.
+
+##### Suggested Types for Fingerprints
+
+* pgp
+* otr
+* ssl
+
+##### Suggested Attributes for Fingerints
+
+*none*
+
 #### Payments
 
 A user's payment details for various payment methods, including Bitcoin and other cryptocurrencies. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
-
-#### PGP
-
-A user's PGP key. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
 
 ### Example
 <pre><code>{

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -4,6 +4,7 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 [View the full JSON schema](/openspecs/userschema_rfc/schema.py).
 
+
 ### Sections
 
 #### Basics
@@ -136,7 +137,16 @@ A list of public key fingerprints associated with a user.
 
 #### Payments
 
-A user's payment details for various payment methods, including Bitcoin and other cryptocurrencies. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.
+A list of the user's payment details for various payment methods, including Bitcoin and other cryptocurrencies.
+
+##### Suggested Types for Payments
+
+* bitcoin
+* *any other cryptocyrrency name*
+
+##### Suggested Attributes for Payments
+
+*none*
 
 ### Example
 <pre><code>{
@@ -165,7 +175,8 @@ A user's payment details for various payment methods, including Bitcoin and othe
         "url": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"
     }],
     "payments": [{
-        "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
+        "type": "bitcoin",
+        "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
     }],
     "v": "0.3"
 }</code></pre>

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -13,12 +13,12 @@ A list of names associated with a user.
 
 Each name must have one category, and zero or more attributes.
 
-##### Suggested Types for Names
+##### Suggested Types
 
 * personal
 * business
 
-##### Suggested Attributes for Names
+##### Suggested Attributes
 
 * legal
 * nick
@@ -35,12 +35,12 @@ Each url must have one category, and zero or more attributes.
 
 A user can establish proof of ownership outside of this schema by placing a file in their website's directory (potentially either the root directory or .well-known directory) that references them as an owner or team member of the organization that runs the site.
 
-##### Suggested Types for URLs
+##### Suggested Types
 
 * website
 * file
 
-##### Suggested Attributes for URLs
+##### Suggested Attributes
 
 * personal
 * business
@@ -53,11 +53,11 @@ A user can establish proof of ownership outside of this schema by placing a file
 
 A list of site-specific username associated with a user on specific websites.
 
-##### Suggested Types for Profiles
+##### Suggested Types
 
 * *canonical link to the site (example: https://www.facebook.com)*
 
-##### Suggested Attributes for Profiles
+##### Suggested Attributes
 
 * *optional link to the user's profile page*
 
@@ -65,12 +65,12 @@ A list of site-specific username associated with a user on specific websites.
 
 A list of link to a user's images, including avatars and cover photos. Images can include Gravatar-compatible ratings as attributes.
 
-##### Suggested Types for Images
+##### Suggested Types
 
 * avatar
 * cover
 
-##### Suggested Attributes for Images
+##### Suggested Attributes
 
 * personal
 * business
@@ -83,13 +83,13 @@ A list of link to a user's images, including avatars and cover photos. Images ca
 
 A list of asynchronous communication (email-like) addresses associated with a user.
 
-##### Suggested Types for Mail
+##### Suggested Types
 
 * email
 * bitmessage
 * freemail
 
-##### Suggested Attributes for Mail
+##### Suggested Attributes
 
 * personal
 * business
@@ -100,7 +100,7 @@ A list of asynchronous communication (email-like) addresses associated with a us
 
 A list of synchronous communication (instant messaging) addresses associated with a user, including voice/video methods.
 
-##### Suggested Types for IM
+##### Suggested Types
 
 * phone
 * xmpp
@@ -108,7 +108,7 @@ A list of synchronous communication (instant messaging) addresses associated wit
 * aim
 * skype
 
-##### Suggested Attributes for IM
+##### Suggested Attributes
 
 * personal
 * business
@@ -121,13 +121,13 @@ A list of synchronous communication (instant messaging) addresses associated wit
 
 A list of public key fingerprints associated with a user.
 
-##### Suggested Types for Fingerprints
+##### Suggested Types
 
 * pgp
 * otr
 * ssl
 
-##### Suggested Attributes for Fingerints
+##### Suggested Attributes
 
 *none*
 
@@ -135,12 +135,12 @@ A list of public key fingerprints associated with a user.
 
 A list of the user's payment details for various payment methods, including Bitcoin and other cryptocurrencies.
 
-##### Suggested Types for Payments
+##### Suggested Types
 
 * bitcoin
 * *any other cryptocyrrency name*
 
-##### Suggested Attributes for Payments
+##### Suggested Attributes
 
 * personal
 * business
@@ -151,12 +151,12 @@ A list of the user's payment details for various payment methods, including Bitc
 
 A list of the user's location details.
 
-##### Suggested Types for Locations
+##### Suggested Types
 
 * home
 * business
 
-##### Suggested Attributes for Locations
+##### Suggested Attributes
 
 * country
 * region
@@ -170,12 +170,27 @@ A list of the user's location details.
 
 A list of short text strings which a user can associate with their entry
 
-##### Suggested Types for Text
+##### Suggested Types
 
 * bio
 * tagline
 
-##### Suggested Attributes for Text
+##### Suggested Attributes
+
+*none*
+
+#### Proofs
+
+This section contains a list of Namecoin identifiers where proof information is stored. Proofs allow for any identity to attest to the validity of any information claimed by any other user.
+
+Users can split their proof information into two types of entries: attestations they've made about other users, and attestations they've received from other users.
+
+##### Suggested Types:
+
+* incoming
+* outgoing
+
+##### Suggested Attributes:
 
 *none*
 

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -19,9 +19,9 @@ There are two global attributes which can be applied to any object, regardless o
 * primary
 * old
 
-The <pre>primary<pre> attribute indicates the default object to be used when more then object of a given type or type/attribute exist. 
+The *primary* attribute indicates the default object to be used when more then object of a given type or type/attribute exist. 
 
-The <pre>old</pre> attributes that an object should no longer be used, and is only included in the entry for historical reasons.
+The *old* attributes that an object should no longer be used, and is only included in the entry for historical reasons.
 
 ### Sections
 

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -10,6 +10,24 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 A user's basic information, including their name, location and bio.
 
+#### Names
+
+An array of names associated with a user. Each name must have one category, and zero or more attributes.
+
+##### Suggested Types for Names
+
+* personal
+* business
+
+##### Suggested Attributes for Names
+
+* legal
+* nick
+* married
+* maiden
+* stage
+* pen
+
 #### Photos
 
 A user's photos, including their avatar and cover photo.
@@ -38,9 +56,13 @@ A user's email addresses.
 <pre><code>{
     "basics": {
         "bio": "Co-founder AngelList \\u2022 Founder Epinions, Vast \\u2022 Author Startupboy, Venture Hacks \\u2022 Investor Twitter, Uber, Yammer, Postmates", 
-        "name": "Naval Ravikant", 
         "location": "San Francisco, CA"
     },
+    "names": [{
+        "type": "personal",
+        "attributes": [{ "legal" }],
+        "name": "Naval Ravikant"
+    }],
     "payments": [{
         "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
     }],

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -7,10 +7,6 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 ### Sections
 
-#### Basics
-
-A user's basic information, including their location and bio.
-
 #### Names
 
 A list of names associated with a user.
@@ -169,6 +165,19 @@ A list of the user's location details.
 * postal code
 * permanent
 * temporary
+
+#### Text
+
+A list of short text strings which a user can associate with their entry
+
+##### Suggested Types for Text
+
+* bio
+* tagline
+
+##### Suggested Attributes for Text
+
+*none*
 
 ### Example
 <pre><code>{

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -12,7 +12,9 @@ A user's basic information, including their location and bio.
 
 #### Names
 
-An array of names associated with a user. Each name must have one category, and zero or more attributes.
+A list of names associated with a user.
+
+Each name must have one category, and zero or more attributes.
 
 ##### Suggested Types for Names
 
@@ -28,6 +30,28 @@ An array of names associated with a user. Each name must have one category, and 
 * stage
 * pen
 
+#### URLs
+
+A list of URLs associated with a user, which may include websites, public keys, or another link they may which to associate with their identity. Links to avatar images should not be added to this section as they as handled in their own section.
+
+Each url must have one category, and zero or more attributes.
+
+A user can establish proof of ownership outside of this schema by placing a file in their website's directory (potentially either the root directory or .well-known directory) that references them as an owner or team member of the organization that runs the site.
+
+##### Suggested Types for URLs
+
+* website
+* file
+
+##### Suggested Attributes for URLs
+
+* personal
+* business
+* blog
+* wiki
+* store
+* *public key identifier*
+
 #### Photos
 
 A user's photos, including their avatar and cover photo.
@@ -39,10 +63,6 @@ A user's payment details for various payment methods, including Bitcoin and othe
 #### Profiles
 
 A user's social network profiles. A user can provide the appropriate usernames or urls, as well as provide proof of ownership of their accounts by referencing posts that only they could have produced (tweets, gists, etc.).
-
-#### Websites
-
-A list of a user's websites. A user can establish proof of ownership outside of this schema by placing a file in their website's directory (potentially either the root directory or .well-known directory) that references them as an owner or team member of the organization that runs the site.
 
 #### PGP
 
@@ -63,6 +83,10 @@ A user's email addresses.
         "attributes": [{ "legal" }],
         "name": "Naval Ravikant"
     }],
+    "urls": [{
+        "type": "website",
+        "url": "https://angel.co/naval"
+    }],
     "payments": [{
         "type": "bitcoin", "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
     }],
@@ -75,9 +99,6 @@ A user's email addresses.
     }, {
         "type": "cover",
         "url": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"
-    }],
-    "websites": [{
-        "url": "https://angel.co/naval"
     }],
     "v": "0.3"
 }</code></pre>

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -4,6 +4,24 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 [View the full JSON schema](/openspecs/userschema_rfc/schema.py).
 
+### Format
+
+A user's ONS consists of lists of objects. In order to faciliate the greatest possible uses while retaining forward and backward compatibilty, objects and lists are as generic as possible. Objects may have <pre>types</pre> and <pre>attributes</pre> which explain their purpose.
+
+Applications which parse ONS entries need not understand the semantic meaning of every type and attribute, and should display all data which is correctly specified.
+
+Applications which require additional types or attributes for their functionality should use existing ones to the maximum extent possible, and where it is not possible they should add their new types and attributes to this specification.
+
+#### Global Attributes
+
+There are two global attributes which can be applied to any object, regardless of type:
+
+* primary
+* old
+
+The <pre>primary<pre> attribute indicates the default object to be used when more then object of a given type or type/attribute exist. 
+
+The <pre>old</pre> attributes that an object should no longer be used, and is only included in the entry for historical reasons.
 
 ### Sections
 

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -151,6 +151,25 @@ A list of the user's payment details for various payment methods, including Bitc
 * tip
 * donation
 
+#### Locations
+
+A list of the user's location details.
+
+##### Suggested Types for Locations
+
+* home
+* business
+
+##### Suggested Attributes for Locations
+
+* country
+* region
+* locality
+* street
+* postal code
+* permanent
+* temporary
+
 ### Example
 <pre><code>{
     "basics": {

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -8,7 +8,7 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 #### Basics
 
-A user's basic information, including their name, location and bio.
+A user's basic information, including their location and bio.
 
 #### Names
 

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -146,7 +146,10 @@ A list of the user's payment details for various payment methods, including Bitc
 
 ##### Suggested Attributes for Payments
 
-*none*
+* personal
+* business
+* tip
+* donation
 
 ### Example
 <pre><code>{

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -6,7 +6,7 @@ The ONS User Schema v0.2 is planned to be phased out and v0.3 will gradually tak
 
 ### Format
 
-A user's ONS consists of lists of objects. In order to faciliate the greatest possible uses while retaining forward and backward compatibilty, objects and lists are as generic as possible. Objects may have <pre>types</pre> and <pre>attributes</pre> which explain their purpose.
+A user's ONS consists of lists of objects. In order to faciliate the greatest possible uses while retaining forward and backward compatibilty, objects and lists are as generic as possible. Objects may have *types* and *attributes* which explain their purpose.
 
 Applications which parse ONS entries need not understand the semantic meaning of every type and attribute, and should display all data which is correctly specified.
 

--- a/rfcs/0002-rfc-user-schema-v0.3.md
+++ b/rfcs/0002-rfc-user-schema-v0.3.md
@@ -99,6 +99,27 @@ A list of asynchronous communication (email-like) addresses associated with a us
 * student
 * official
 
+#### IM
+
+A list of synchronous communication (instant messaging) addresses associated with a user, including voice/video methods.
+
+##### Suggested Types for IM
+
+* phone
+* xmpp
+* icq
+* aim
+* skype
+
+##### Suggested Attributes for IM
+
+* personal
+* business
+* official
+* land
+* mobile
+* fax
+
 #### Payments
 
 A user's payment details for various payment methods, including Bitcoin and other cryptocurrencies. A user may provide proof of ownership by signing a message stating their blockchain handle and including it in their profile.


### PR DESCRIPTION
All the implicit 1:1 relationships in the previous version have been represented as one-to-many, because users will desire to, for example, attach more than one name or GPG key with their identity.

In order to make the schema as useful as possible to as many applications as possible, all arrays and objects are generic, with object types and attributes used to attach semantic meaning to them.

This means it should be possible to create applications that can properly display an entry without needing to understand every object semantically, and application or users can add their own attributes and types as needed.

Proof has been moved to a seperate entry, which will have its own rfc. Proving identity data should also be generic, with any identity being capable of offering attestations for or against any claim made by any user.
