### PR TITLE
Complete overhaul of Resolver RESTful API.

### DIFF
--- a/resolvers.md
+++ b/resolvers.md
@@ -2,132 +2,70 @@
 
 ***Warning: This document is currently in DRAFT status and therefore may change rapidly and significantly. Do not build production-ready apps based on it yet!***
 
-Resolvers can return data via multiple protocols Currently two protocols are defined by this spec: __HTTP(S)__ (as a RESTful API), and __DNS__.
+Resolvers return blockchain data via multiple protocols. Currently, two protocols are defined the spec: __HTTP(S)__ (as a RESTful API), and __DNS__.
+
+The spec adheres to the [Guiding Principles](<#Guiding>) outlined in the [Appendix](<#Appendix>).
 
 __Table of Contents__
 
 - [HTTP RESTful API (Draft)](<#HTTP>)
-    - [Guiding Principles for resolver API](<#Guiding>)
-    - [Summary of querying mechanisms employed](<#Mechanisms>)
-    - [Specifying what is being queried](<#Specifying>)
     - [Reading and writing to blockchains](<#Reading>)
-        - [Reading from blockchains](<#Reading>)
-        - [Writing from blockchains](<#Writing>)
     - [Resolver information](<#Resolver>)
 - [DNS API (Draft)](<#DNS>)
     - [TLDs for existing blockchain](<#TLDs>)
-    - [MetaTLDs](<#MetaTLDs>)
     - [Records for blockchains](<#Records>)
+    - [metaTLDs (optional)](<#MetaTLDs>)
+- [Appendix](<#Appendix>)
+    - [Guiding Principles for resolver API](<#Guiding>)
 
-## HTTP RESTful API (Draft)<a name="HTTP"/>
+## HTTP RESTful API<a name="HTTP"/>
 
-Resolvers conform to a blockchain-agnostic RESTful API according the following __Guiding Principles:__
+All operations are performed via the URL [path and query string](https://en.wikipedia.org/wiki/Uniform_resource_locator#Syntax).
 
-### Guiding Principles for resolver API<a name="Guiding"/>
+All possible queries that can be performed on a blockchain (both read, write, and delete operations) conform to the following structure:
 
-1. __Agnosticism to maximum extent possible.__ It would be a detriment to blockchain innovation for us to assume there is a "best" blockchain for doing key/value mappings. That is why this spec supports key/value lookups in a blockchain-agnostic manner. For unique features found only in one blockchain, the API should be designed in a generic way that can be adaptable to other blockchains should they implement said feature.
-2. __Maximize both simplicity and usability.__ Start with a simple, solid foundation and build off of it as necessary. Simple requests should have simple formats. Complicated requests should express that complexity in a way that builds off of the simple foundation.
-    - In cases where ambiguity exists about the right design decision, _both_ approaches should be implemented and tested in the real-world. Real-world feedback will determine how to proceed.
-3. __Maximize security and privacy.__ The API must be queriable over a MITM-proof channel. It must be flexible enough to support arbitrary security protocols and cryptography. To the maximum extent possible, the API should be stateless, and must not leak any unnecessary information or metadata about the connection.
-4. __All design decisions must have justifications.__ This improves the quality of the spec by encouraging discussion, and promotes transparency. [[1]](https://forum.namecoin.info/viewtopic.php?p=10750#p10750)
+    /{version}/[{chain}|resolver]/{resource}/{property}/{operation}{resp_format}?{args}
 
-<a name="Mechanisms"/>
-### Summary of querying mechanisms employed
+Examples:
 
-- HTTP headers are used alongside metaTLDs to specify which blockchain is being queried.
-- Subdomains are used (per metaTLD) to specify what functionality is being requested for that blockchain.
-- HTTP verbs `GET` and `POST` are used to read and write data from blockchain RESTful APIs (respectively).
-- The query path is used to specify first the __action__, and then the resource (key) that is being acted upon.
-- The query string is used to pass parameters to actions that accept them.
-- A path extension (like `.json`) may be appended to specify the format of the response.
+    https://api.example.com/v1/namecoin/key/id%2Fbob
+    https://api.example.com/v1/bitcoin/addr/MywyjpyBbFTsHkevcoYnSaifShG2Et8R3S
+    https://api.example.com/v1/namecoin/key/id%2Fclinton/transfer?to_addr=ea3df...
+    http://api.example.com/v1/resolver/fingerprint
 
-This specification intentionally does not make full use of all possible HTTP verbs. If one of these verbs is necessary (such as writing) to blockchains, `POST` can be used.
-The reasoning for this decision is multifold:
+Unless marked __Optional__, all parts are required:
 
-- The API can function perfectly well with just `GET`. Therefore, relying too much on verbs violates Guideline #2 (maximize simplicity).
-- Requiring clients to deal with which verb to use violates Guideline #2 (maximize usability).
-- The verbs do not capture all of the actions a resolver might perform.
-- The verbs can be easily expressed as actions via the query path of the URL.
+- `{version}`: Specifies the API version. This value should be `v1` for now.
+- `[{chain}|resolver]`: Specifies the full name of the blockchain, or request [resolver-specific information](<#ResolverInfo>).
+- `{resource}`: Blockchains can support different resources that can be queried, but most support the same types of resources. For example, all blockchains (by definition) have a `blocks` resource. Examples: `blocks`, `txn`, `txns`, `addr`, `key`, `accounts`, `contracts`.
+- `{property}` __(Optional):__ Specifies a property of a `{resource}`. Depending on the resource being queried, this can be used to refer to different things. Properties MUST be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding)! Example queries:
+    + `/v1/namecoin/blocks/height` - The height of the blockchain (positive integer).
+    + `/v1/namecoin/addr/MywyjpyBbFTsHkevcoYnSaifShG2Et8R3S` - Return information about this address.
+- `{operation}` __(Optional):__ Perform some action on a `{resource}` or a `{property}` of a resource. Example queries:
+    + `/v1/namecoin/key/d%2Fgreatwebsite/transfer` - Transfer the key (in this case the domain `greatwebsite.bit`) to a new owner (specified by `{args}`).
+    + `/v1/namecoin/key/u%2Fryan` - Return the JSON stored in the Namecoin blockchain for `/u/ryan`.
+- `{resp_format}` __(Optional):__ The response format. __Default__ response format is JSON. Resolvers MUST support `.json` and MAY support other formats. Examples:
+    + `/v1/namecoin/blocks/height.xml` - Return response in XML instead of JSON.
+- `{args}` __(Optional):__ The URL-encoded arguments to some `{operation}`. Examples:
+    + `/v1/namecoin/key/d%2Fgreatwebsite/transfer?to_addr=MywyjpyBbFTsHkevcoYnSaifShG2Et8R3S` - Transfers `greatwebsite.bit` to the owner at the specified address on the Namecoin blockchain.
 
-### Specifying what is being queried<a name="Specifying"/>
+<a name="Reading"/>
+### Typical resources and operations across blockchains
 
-Resolvers CAN support multiple _functionalities_ and multiple _blockchains_. They MUST support: at least one blockchain metaTLD, at least one blockchain TLD, and the corresponding `api.` subdomain functionality.
+__TBD: actual specs. Can infer from examples.__
 
-To specify the blockchain being queried, two HTTP headers are supported: `HOST` and `BLOCKCHAIN`. The `HOST` header is used as convenience when using a resolver for DNS via the [`.dns` metaTLD](<#metatlds>).
+Data being written SHOULD be placed into the body of the request, following standard `POST` semantics.
 
-__Examples: Specifying the desired blockchain via HTTP headers__
+<a name="ResolverInfo"/>
+### Resolver-specific information
 
-| Desired blockchain |       HTTP header        |
-|--------------------|--------------------------|
-| Namecoin           | HOST: namecoin.dns       |
-| KeyID              | HOST: bitshares.dns      |
-| Ethereum           | HOST: ethereum.dns       |
-| Namecoin           | BLOCKCHAIN: namecoin.dns |
+Resolver-specific functionality MAY be provided should resolvers choose to provide resolver-specific information.
 
-To specify the desired functionality, the first-level subdomain is used.
+For example, a resolver can provide its TLS fingerprint like so:
 
-__Examples: Specifying the desired functionality via HTTP headers__
+- `/v1/resolver/fingerprint`
 
-|     Desired Feature      |            HTTP header            |
-|--------------------------|-----------------------------------|
-| RESTful API for Namecoin | HOST: api.namecoin.dns            |
-| RESTful API for Ethereum | BLOCKCHAIN: api.ethereum.dns      |
-| Blockchain explorer      | HOST: explorer.namecoin.dns       |
-| Blockchain explorer      | BLOCKCHAIN: explorer.namecoin.dns |
-
-- Note: if clients are using the resolver for DNS, most programs will automatically set the `HOST` header when a request is made to the metaTLD.
-
-### Reading and writing to blockchains<a name="Reading"/>
-
-_TBD: actual specs. Can infer from examples._
-
-The RESTful API is accessed through the `api.` subdomain.
-
-#### Reading from blockchains<a name="Reading"/>
-
-Resolvers MUST support the `GET` verb for all read actions, and MAY support other verbs for this function at their discretion.
-Changing the verb MUST NOT impact the response the resolver sends.
-
-The format of the query path is: `/read/{key}[.{extension}]` where:
-
-- `{key}` is the key being looked up in the blockchain
-- `{extension}` is an optional data format for the response
-
-__Examples: Querying user profile information__
-
-|           Desired Data           |         HTTP Header          |         Query          |
-|----------------------------------|------------------------------|------------------------|
-| XML for `/u/ryan` in Namecoin    | BLOCKCHAIN: api.namecoin.dns | GET /read/u/ryan.xml   |
-| JSON for `/u/muneeb` in Namecoin | HOST: api.namecoin.dns       | GET /read/u/muneeb     |
-| JSON for `/id/greg` in Namecoin  | BLOCKCHAIN: api.namecoin.dns | GET /read/id/greg.json |
-
-_Note that JSON is the default when the extension isn't specified._
-
-#### Writing to blockchains<a name="Writing"/>
-
-_TBD: [copy from namecoin forum](https://forum.namecoin.info/viewtopic.php?p=10750#p10750)._
-
-These will probably take the form of:
-
-- `POST /update/{key}`
-- `POST /transfer/{key}?to={new_owner_address}` (exact semantics TBD)
-- `POST /delete/{key}`
-- etc.
-
-Note that *the same RESTful API* MUST be used across all blockchains to ensure a generic, agnostic approach.
-If one blockchain supports a unique action that other blockchains do not, then its interface will act as the
-blueprint that will be used on other blockchains (should they support the action in the future). Therefore
-the design of all actions must be as general and agnostic as possible.
-
-The data being written SHOULD be placed into the body of the request, following standard `POST` semantics.
-
-### Resolver information<a name="Resolver"/>
-
-If resolvers wish to provide resolver-specific functionality that does relate to blockchain-specific
-data, they SHOULD do so over a separate, resolver-specific metaTLD, the API details of which are up
-to the resolver to decide.
-
-For example, the DNSChain reference resolver supports retrieving its fingerprint over `api.dnschain.dns/fingerprint`.
+__TBD: Specify possible resources and their response format.__
 
 ## DNS API (Draft)<a name="DNS"/>
 
@@ -147,14 +85,26 @@ Existing blockchain TLDs are listed below:
 
 _Note: blockchains should choose TLDs that do not conflict with any existing ICANN TLDs (and ICANN should do the same)._ 
 
-#### MetaTLDs<a name="MetaTLDs"/>
-
-MetaTLDs are TLDs that [resolve to the IP of the resolver itself](http://blog.okturtles.com/2014/02/introducing-the-dotdns-metatld/).
-
-Resolvers conforming to this spec MUST support the `.dns` metaTLD, and return all queries to this TLD with an `A` record specifying the resolver's public facing IP address.
+Resolvers conforming to this spec MAY support the `.dns` metaTLD, and return all queries to this TLD with an `A` record specifying the resolver's public facing IP address.
 
 #### Records for blockchains<a name="Records"/>
 
 | DNS Record |    Blockchain use   |
 |------------|---------------------|
 | TLSA       | _TBD: fill this in_ |
+
+#### metaTLDs<a name="MetaTLDs"/>
+
+metaTLDs are TLDs that [resolve to the IP of the resolver itself](http://blog.okturtles.com/2014/02/introducing-the-dotdns-metatld/).
+
+<a name="Appendix"/>
+## Appendix
+
+<a name="Guiding"/>
+#### Guiding Principles for resolver API
+
+1. __Agnosticism to maximum extent possible.__ It would be a detriment to blockchain innovation for us to assume there is a "best" blockchain for doing key/value mappings. That is why this spec supports key/value lookups in a blockchain-agnostic manner. For unique features found only in one blockchain, the API should be designed in a generic way that can be adaptable to other blockchains should they implement said feature.
+2. __Maximize both simplicity and usability.__ Start with a simple, solid foundation and build off of it as necessary. Simple requests should have simple formats. Complicated requests should express that complexity in a way that builds off of the simple foundation.
+    - In cases where ambiguity exists about the right design decision, _both_ approaches should be implemented and tested in the real-world. Real-world feedback will determine how to proceed.
+3. __Maximize security and privacy.__ The API must be queriable over a MITM-proof channel. It must be flexible enough to support arbitrary security protocols and cryptography. To the maximum extent possible, the API should be stateless, and must not leak any unnecessary information or metadata about the connection.
+4. __All design decisions must have justifications.__ This improves the quality of the spec by encouraging discussion, and promotes transparency. [[1]](https://forum.namecoin.info/viewtopic.php?p=10750#p10750)

--- a/resolvers.md
+++ b/resolvers.md
@@ -24,7 +24,7 @@ All operations are performed via the URL [path and query string](https://en.wiki
 
 All possible queries that can be performed on a blockchain (both read, write, and delete operations) conform to the following structure:
 
-    /{version}/[{chain}|resolver]/{resource}/{property}/{operation}{resp_format}?{args}
+    /{version}/{chain|resolver}/{resource}/{property}/{operation}{resp_format}?{args}
 
 Examples:
 
@@ -36,14 +36,13 @@ Examples:
 Unless marked __Optional__, all parts are required:
 
 - `{version}`: Specifies the API version. This value should be `v1` for now.
-- `[{chain}|resolver]`: Specifies the full name of the blockchain, or request [resolver-specific information](<#ResolverInfo>).
+- `{chain|resolver}`: Specifies the full name of the blockchain, or request [resolver-specific information](<#ResolverInfo>).
 - `{resource}`: Blockchains can support different resources that can be queried, but most support the same types of resources. For example, all blockchains (by definition) have a `blocks` resource. Examples: `blocks`, `txn`, `txns`, `addr`, `key`, `accounts`, `contracts`.
 - `{property}` __(Optional):__ Specifies a property of a `{resource}`. Depending on the resource being queried, this can be used to refer to different things. Properties MUST be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding)! Example queries:
     + `/v1/namecoin/blocks/height` - The height of the blockchain (positive integer).
     + `/v1/namecoin/addr/MywyjpyBbFTsHkevcoYnSaifShG2Et8R3S` - Return information about this address.
 - `{operation}` __(Optional):__ Perform some action on a `{resource}` or a `{property}` of a resource. Example queries:
     + `/v1/namecoin/key/d%2Fgreatwebsite/transfer` - Transfer the key (in this case the domain `greatwebsite.bit`) to a new owner (specified by `{args}`).
-    + `/v1/namecoin/key/u%2Fryan` - Return the JSON stored in the Namecoin blockchain for `/u/ryan`.
 - `{resp_format}` __(Optional):__ The response format. __Default__ response format is JSON. Resolvers MUST support `.json` and MAY support other formats. Examples:
     + `/v1/namecoin/blocks/height.xml` - Return response in XML instead of JSON.
 - `{args}` __(Optional):__ The URL-encoded arguments to some `{operation}`. Examples:

--- a/resolvers.md
+++ b/resolvers.md
@@ -1,5 +1,7 @@
 # Resolvers (DRAFT)
 
+***Warning: This document is currently in DRAFT status and therefore may change rapidly and significantly. Do not build production-ready apps based on it yet!***
+
 Resolvers can return data via multiple protocols Currently two protocols are defined by this spec: __HTTP(S)__ (as a RESTful API), and __DNS__.
 
 __Table of Contents__
@@ -105,15 +107,27 @@ _Note that JSON is the default when the extension isn't specified._
 
 _TBD: [copy from namecoin forum](https://forum.namecoin.info/viewtopic.php?p=10750#p10750)._
 
-These will probably take the form of: `POST /write/{key}`
+These will probably take the form of:
+
+- `POST /update/{key}`
+- `POST /transfer/{key}?to={new_owner_address}` (exact semantics TBD)
+- `POST /delete/{key}`
+- etc.
+
+Note that *the same RESTful API* MUST be used across all blockchains to ensure a generic, agnostic approach.
+If one blockchain supports a unique action that other blockchains do not, then its interface will act as the
+blueprint that will be used on other blockchains (should they support the action in the future). Therefore
+the design of all actions must be as general and agnostic as possible.
 
 The data being written SHOULD be placed into the body of the request, following standard `POST` semantics.
 
 ### Resolver information<a name="Resolver"/>
 
-| `HOST` or `BLOCKCHAIN` Header | HTTP verb |               Query                |               Returns               |
-|-------------------------------|-----------|------------------------------------|-------------------------------------|
-| api.namecoin.dns              | _ANY_     | /fingerprint{. [json &#x7C; xml]} | _TBD: format of SHA256 fingerprint_ |
+If resolvers wish to provide resolver-specific functionality that does relate to blockchain-specific
+data, they SHOULD do so over a separate, resolver-specific metaTLD, the API details of which are up
+to the resolver to decide.
+
+For example, the DNSChain reference resolver supports retrieving its fingerprint over `api.dnschain.dns/fingerprint`.
 
 ## DNS API (Draft)<a name="DNS"/>
 


### PR DESCRIPTION
- Got rid of HTTP headers `HOSTNAME` and `BLOCKCHAIN`
- Focused entirely on URL format.
