### PR TITLE
Fix the link for blockstack.js in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you're just starting with Blockstack, here are the main software repositories
 
 - [Blockstack Core](https://github.com/blockstack/blockstack-core) - the reference implementation of Blockstack written in Python.
 - [Blockstack Portal](https://github.com/blockstack/blockstack-portal) - the Blockstack Browser Portal providing a graphical interface.
-- [blockstack.js](https://github.com/blockstack/blockstack-portal) - a JavaScript library for using Blockstack identity and authentication in your apps.
+- [blockstack.js](https://github.com/blockstack/blockstack.js) - a JavaScript library for using Blockstack identity and authentication in your apps.
 
 ## Tutorials
 


### PR DESCRIPTION
It was previously linking to https://github.com/blockstack/blockstack-portal when it should in fact link to https://github.com/blockstack/blockstack.js