### PR TITLE
docs: add StacksHurry to community apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ If you're just starting with Stacks, here are the main software repositories you
 - [stacks.js](https://github.com/hirosystems/stacks.js) - a JavaScript library for using identity, auth, and storage in your apps.
 - [Stacks Explorer](https://github.com/hirosystems/explorer) - explorer for Stacks layer.
 
+## Community Apps
+
+Projects built on Stacks by the community:
+
+| App | Description |
+|-----|-------------|
+| [StacksHurry](https://stackshurry.vercel.app) | On-chain rocket shooter game with Clarity smart contracts for scoring, pilot registry, NFT minting, and powerup store. npm: `stacks-hurry` |
+
 ## How to Help
 
 - **Contribute open-source code** - send us pull requests with improvements! See some [good first issues](https://github.com/stacks-network/stacks-blockchain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).


### PR DESCRIPTION
## What
Adds StacksHurry to the ecosystem showcase as an example of a community-built game on Stacks.

## About the project
StacksHurry is a production rocket shooter game on Stacks mainnet:
- 7 Clarity smart contracts deployed at SP1YH5MXTJT86BZXMFA2T51JF0QVZ8XNYV33QH6MF
- On-chain scoring, pilot registry, powerup store, daily quest tracking, NFT minting
- Reusable open-source SDK published to npm: `npm install stacks-hurry`
- Source: https://github.com/Dark-Brain07/StacksHurry
- Live: https://stackshurry.vercel.app

It's a good example of what's possible with Clarity for game developers.